### PR TITLE
Updated pxchallenge.lua and pxnginx.lua

### DIFF
--- a/lua/pxchallenge.lua
+++ b/lua/pxchallenge.lua
@@ -14,19 +14,32 @@ function sendTo_Perimeter()
     pxdata['pxtoken'] = ngx.ctx.pxtoken;
     pxdata['pxidentifier'] = ngx.ctx.pxidentifier;
     pxdata = json.encode(pxdata);
-    if not (ngx.ctx.px_apiServer == nil) then
+    local apiServer = ngx.ctx.px_apiServer;
+    if apiServer ~= nil and apiServer ~= "" then
         local submit = function()
            local httpc = http.new()
-           local res, err = httpc:request_uri(ngx.ctx.px_apiServer .. '/api/v1/collector/nginxcollect', {
-                method = "POST",
+           local res, err = httpc:request_uri(apiServer .. '/api/v1/collector/nginxcollect', {
+               method = "POST",
                body = "data=" .. pxdata,
-                headers = {
+               headers = {
                     ["Content-Type"] = "application/x-www-form-urlencoded",
                 }
             })
-        end
 
-        ngx.timer.at(1, submit)
+	if not res then
+	    ngx.log(ngx.ERR, "failed to make http post: ",err)
+	    return
+	elseif res.status ~= 200 then
+	    ngx.log(ngx.ERR, "Non 200 response code: ", res.status)
+        end
+	end
+
+        local ok, err = ngx.timer.at(1, submit)
+	if not ok then
+	    ngx.log(ngx.ERR, "Failed timer for submit: ", err)
+	    return
+  	end
+
     end
 end
 
@@ -35,4 +48,3 @@ sendTo_Perimeter();
 -- Sending the javascript challenge back to the client - expect a cookie set
 ngx.header["Content-type"] = "text/html"
 ngx.say('<H1 style="display: none;">You are not authorized to view this page - PerimeterX.</H1><script>var str = "' .. ngx.ctx.pxidentifier .. '";var strx = "";for (var i = 0; i < str.length; i++) {    strx += str[i];    if ((i + 1) % 4 == 0) {        strx += Math.random().toString(36).substring(3, 4);    }};document.cookie = "_pxcook=" + strx;window.location.reload();</script>');
-

--- a/lua/pxnginx.lua
+++ b/lua/pxnginx.lua
@@ -7,7 +7,7 @@
 -- ## Configuration Block ##
 local px_token = 'my_temporary_token';
 local px_appId = 'PXAPPCODE';
-local px_apiServer = 'https://pxcollector.a.pxi.pub';
+local px_apiServer = 'https://collector.a.pxi.pub';
 local cookie_lifetime = 600 -- cookie lifetime, value in seconds
 -- ## END - Configuration block ##
 
@@ -21,7 +21,7 @@ function gen_pxIdentifier()
 end
 
 -- Validating the user key came from px-cookie and match against the locally generated one
-function validate_pxIdentidier(identifier, px_cookie)
+function validate_pxIdentifier(identifier, px_cookie)
     local re_pxcook = ''
 
     -- if no cookie we stop validation
@@ -70,7 +70,7 @@ ngx.ctx.px_apiServer = px_apiServer;
 ngx.ctx.px_token = px_token;
 local pxcook = ngx.var.cookie__pxcook;
 
-if not validate_pxIdentidier(ngx.ctx.pxidentifier, pxcook) then
+if not validate_pxIdentifier(ngx.ctx.pxidentifier, pxcook) then
     return 1;
 end
 


### PR DESCRIPTION
In pxchallenge.lua added local variable apiServer since ngx.ctx var was returning nil and causing error message of concatenation failure.

Added error check for http post call with error message in nginx erorr log.

Added error check for timer not executing with error message in nginx error log.

In pxnginx.lua corrected the collector uri.

Renamed validate_pxIdentidier to validate_pxIdentifier for spelling.
