### PR TITLE
Custom captcha as 403, inject js from lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,15 +321,15 @@ _M.custom_block_url /block.html
         }
        
        // http://stackoverflow.com/questions/901115/how-can-i-get-query-string-values-in-javascript
-		function getQueryString(name, url) {
-		    if (!url) url = window.location.href;
-		    name = name.replace(/[\[\]]/g, "\\$&");
-		    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
-		        results = regex.exec(url);
-		    if (!results) return null;
-		    if (!results[2]) return '';
-		    return decodeURIComponent(results[2].replace(/\+/g, " "));
-		}
+	function getQueryString(name, url) {
+		if (!url) url = window.location.href;
+		name = name.replace(/[\[\]]/g, "\\$&");
+		var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+			results = regex.exec(url);
+		if (!results) return null;
+		if (!results[2]) return '';
+		return decodeURIComponent(results[2].replace(/\+/g, " "));
+	}
 
         </script>
     </head>

--- a/lib/px/block/pxblock.lua
+++ b/lib/px/block/pxblock.lua
@@ -18,6 +18,13 @@ function _M.load(config_file)
     local px_constants = require "px.utils.pxconstants"
     local ngx_exit = ngx.exit
 
+    local function new_captcha_script(vid, uuid) 
+        local captchaScript = '<script src="https://www.google.com/recaptcha/api.js"></script><script type="text/javascript">window.px_vid = "::VID::"; function handleCaptcha(response){var vid="::VID::";var uuid="::UUID::";var name="_pxCaptcha";var expiryUtc=new Date(Date.now()+1000*10).toUTCString();var cookieParts=[name,"=",response+":"+vid+":"+uuid,"; expires=",expiryUtc,"; path=/"];document.cookie=cookieParts.join("");location.reload()}</script>'
+        captchaScript = string.gsub(captchaScript, '::VID::', vid)
+        captchaScript = string.gsub(captchaScript, '::UUID::', uuid)
+        return captchaScript
+    end
+
     function _M.block(reason)
         local details = {}
         local ref_str = ''
@@ -50,21 +57,20 @@ function _M.load(config_file)
         if px_config.block_enabled then
             ngx.header["Content-Type"] = 'text/html';
             if px_config.custom_block_url then
-                -- handling custom block url: create redirect url with original request url, vid and uuid as query params to use with captcha_api
-                local req_query_param = ngx.req.get_uri_args()
-                local enc_query_params
-                local original_req_url = ngx.var.uri
-                if req_query_param then
-                    enc_query_params =  ngx_encode_args(req_query_param)
-                    original_req_url = original_req_url .. '?' .. enc_query_params
+                local res = ngx.location.capture(px_config.custom_block_url)
+                if res.truncated or res.status >= 300 then 
+                    ngx.status(500)
+                    ngx_exit(ngx.OK)
                 end
-                local redirect_url = px_config.custom_block_url .. '?url=' .. original_req_url .. '&uuid=' .. uuid .. '&vid=' .. vid
-                px_logger.debug('Redirecting to custom block page: ' .. redirect_url)
-                ngx_redirect(redirect_url, ngx_HTTP_TEMPORARY_REDIRECT)
+                local body = string.gsub(res.body, '</head>', new_captcha_script(vid, uuid) .. '</head>', 1);
+                local body = string.gsub(body, '::BLOCK_REF::', uuid);
+                ngx.status = ngx_HTTP_FORBIDDEN;
+                ngx_say(body);
+                ngx_exit(ngx.OK);
             end
             ngx.status = ngx_HTTP_FORBIDDEN;
             if px_config.captcha_enabled then
-                local head = '<head><link type="text/css" rel="stylesheet" media="screen, print" href="//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800"> <meta charset="UTF-8"> <title>Access to This Page Has Been Blocked</title> <style> p { width: 60%; margin: 0 auto; font-size: 35px; } body { background-color: #a2a2a2; font-family: "Open Sans"; margin: 5%; } img { widht: 180px; } a { color: #2020B1; text-decoration: blink; } a:hover { color: #2b60c6; } </style> <style type="text/css"></style> <script src="https://www.google.com/recaptcha/api.js"></script> <script> window.px_vid = "' .. vid .. '"; function handleCaptcha(response) { var name = "_pxCaptcha"; var expiryUtc = new Date( Date.now() + 1000 * 10 ).toUTCString(); var cookieParts = [name, "=", response + ":" + window.px_vid + ":' .. uuid .. '", "; expires=", expiryUtc, "; path=/"]; document.cookie = cookieParts.join(""); location.reload(); } </script> </head>'
+                local head = '<head><link type="text/css" rel="stylesheet" media="screen, print" href="//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800"> <meta charset="UTF-8"> <title>Access to This Page Has Been Blocked</title> <style> p { width: 60%; margin: 0 auto; font-size: 35px; } body { background-color: #a2a2a2; font-family: "Open Sans"; margin: 5%; } img { widht: 180px; } a { color: #2020B1; text-decoration: blink; } a:hover { color: #2b60c6; } </style> <style type="text/css"></style> ' .. new_captcha_script(vid, uuid) .. ' </head>'
                 local body = '<body cz-shortcut-listen="true"> <div><img src="http://storage.googleapis.com/instapage-thumbnails/035ca0ab/e94de863/1460594818-1523851-467x110-perimeterx.png"> </div> <span style="color: white; font-size: 34px;">Access to This Page Has Been Blocked</span> <div style="font-size: 24px;color: #000042;"><br> Access to this page is blocked according to the website security policy. <br> Your browsing activity made us think you may be a bot. <br> <br> This may happen as a result of the following: <ul> <li>JavaScript is disabled or not running properly.</li> <li>Your browsing behaviour is not likely to be a regular user.</li> </ul> To read more about the bot defender solution: <a href="https://www.perimeterx.com/bot-defender">https://www.perimeterx.com/bot-defender</a> <br> If you think the blocking was done by mistake, contact the site administrator. <br> <div class="g-recaptcha" data-sitekey="6Lcj-R8TAAAAABs3FrRPuQhLMbp5QrHsHufzLf7b" data-callback="handleCaptcha" data-theme="dark"></div><br> </br> ' .. ref_str .. ' </div>';
                 ngx_say('<html lang="en">' .. head .. body .. '</html>');
             else

--- a/t/003-block.t
+++ b/t/003-block.t
@@ -125,6 +125,11 @@ Test the redirect flow
     real_ip_header     X-Forwarded-For;
 
 --- config
+    location = /block.html {
+        content_by_lua_block {
+            ngx.say("BLOCKPAGE")
+        }
+    }
     location = /t {
         resolver 8.8.8.8;
 	    set_by_lua_block $config {
@@ -151,8 +156,8 @@ X-Forwarded-For: 1.2.3.4
 User-Agent:  Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36
 
 --- response_body_like
-.*307 Temporary Redirect.*
---- error_code: 307
+.*BLOCKPAGE.*
+--- error_code: 403
 
 --- error_log
 PX DEBUG: Visitor score is higher than allowed threshold: 100


### PR DESCRIPTION
This change avoids using a 307 redirect for blocking with a custom captcha page. Instead the custom captcha page is fetched as an nginx subrequest, modified to inject the required JS with VID and UUID, then returned at the original (blocked) URL with the status 403. 

This is easier to understand in logs, requires fewer requests by the client, doesn't lead to URL encoding/redirection bugs, and 403 is a more descriptive code than 307 -> 200 so clients (browsers, jquery, crawlers) should behave better.

As an additional benefit, it centralizes the captcha JS in one place (in code) and removes that JS from the documentation because it no longer has to be handled by the PX customer. 

Summary of changes:

* Do custom captcha page on original URI with an HTTP 403 instead of redirect
* Inject handleCaptcha JS from LUA instead of copy/pasting from plugin to application code
* DRY the JS
* Update tests

This could all be put behind a config parameter if the current custom captcha 307 behavior needs to remain the default. 

With this change, docs would need to be updated to say something like:

> Custom captcha page needs:
> 
> * Nothing special in the <head> (no copy/pasting JS around)
> * Where you want your captcha box: `<div class="g-recaptcha captcha-box" data-sitekey="6Lcj-R8TAAAAABs3FrRPuQhLMbp5QrHsHufzLf7b" data-callback="handleCaptcha" data-theme="light"></div>` 
> * Optional: `::BLOCK_REF::` will be replaced by the block reference (UUID) for debugging.

Tests pass for me.

Would like to see this upstream. Let me know what you think; comments and concerns welcome. My Lua/OpenResty is beginner level. 
