### PR TITLE
fix for ngx.status

### DIFF
--- a/lib/px/block/pxblock.lua
+++ b/lib/px/block/pxblock.lua
@@ -61,7 +61,8 @@ function M.load(config_file)
                 if not px_config.redirect_on_custom_url then
                     local res = ngx.location.capture(px_config.custom_block_url)
                     if res.truncated or res.status >= 300 then
-                        ngx.status(500)
+                        ngx.status = 500
+                        ngx_say('Unable to fetch custom block url. Status: ' .. tostring(res.status))
                         ngx_exit(ngx.OK)
                     end
                     local body = res.body


### PR DESCRIPTION
* fixes incorrect setting of status code introduced [here](https://github.com/PerimeterX/perimeterx-nginx-plugin/pull/26/files#diff-1c8e54862be2439d145ce8451f48fa6eR55)
* calls `ngx_say` to actually write header with status code