### PR TITLE
Move the decodeURI operation before the Base64 decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,10 +301,11 @@ function getQueryString(name, url) {
             results = regex.exec(url);
     if (!results) return null;
     if (!results[2]) return '';
+    results[2] = decodeURIComponent(results[2].replace(/\+/g, " "));
     if(name == "url") {
       results[2] = atob(results[2]); //Not supported on IE Browsers
     }
-    return decodeURIComponent(results[2].replace(/\+/g, " "));
+    return results[2];
 }
 </script>
 ```

--- a/examples/Custom Block Page + reCAPTCHA + Redirect/README.md
+++ b/examples/Custom Block Page + reCAPTCHA + Redirect/README.md
@@ -43,10 +43,11 @@ function getQueryString(name, url) {
             results = regex.exec(url);
     if (!results) return null;
     if (!results[2]) return '';
+    results[2] = decodeURIComponent(results[2].replace(/\+/g, " "));
     if(name == "url") {
       results[2] = atob(results[2]); //Not supported on IE Browsers
     }
-    return decodeURIComponent(results[2].replace(/\+/g, " "));
+    return results[2];
 }
 </script>
 ```

--- a/examples/Custom Block Page + reCAPTCHA + Redirect/block.html
+++ b/examples/Custom Block Page + reCAPTCHA + Redirect/block.html
@@ -77,10 +77,11 @@
                 results = regex.exec(url);
             if (!results) return null;
             if (!results[2]) return '';
+            results[2] = decodeURIComponent(results[2].replace(/\+/g, " "));
             if(name == "url") {
                 results[2] = atob(results[2]);
             }
-            return decodeURIComponent(results[2].replace(/\+/g, " "));
+            return results[2];
         }
         </script>
     </head>


### PR DESCRIPTION
Address issue https://github.com/PerimeterX/perimeterx-nginx-plugin/issues/37

> **atob on URL params throws error**
> When Base64 url param has `=` character, atob operation fails for the URL encoded representation of the symbol (`%3D`)