### PR TITLE
EN-2947 Updated px_cookie_version

### DIFF
--- a/lib/px/utils/pxclient.lua
+++ b/lib/px/utils/pxclient.lua
@@ -128,6 +128,10 @@ function M.load(config_file)
             details['pass_reason'] = ngx.ctx.pass_reason
         end
 
+        if ngx.ctx.px_cookie_version then
+            details["px_cookie_version"] = ngx.ctx.px_cookie_version
+        end
+
         pxdata['details'] = details;
 
         -- Experimental Buffer Support --

--- a/lib/px/utils/pxcookiev3.lua
+++ b/lib/px/utils/pxcookiev3.lua
@@ -14,7 +14,6 @@ function PXCookieV3:validate(data)
     local digest = self.hmac("sha256", self.cookie_secret, request_data)
     digest = self:to_hex(digest)
 
-    -- policy with ip
     if digest == string.upper(ngx.ctx.px_cookie_hmac) then
         return true
     end


### PR DESCRIPTION
1) px_cookie_hmac was already fixed therefore nothing was done with it
2) px_cookie_version was missing on requests (i.e. block). Added to send_to_perimeterx
3) removed unneeded comment from pxcookiev3.lua