### PR TITLE
exit proxy response with correct ngx status code

### DIFF
--- a/lib/px/utils/pxclient.lua
+++ b/lib/px/utils/pxclient.lua
@@ -202,6 +202,8 @@ function M.load(config_file)
 
         httpc:proxy_response(httpc:proxy_request())
         httpc:set_keepalive()
+		-- exit after proxy response with the proxy request status code. 
+		ngx.exit(ngx.status)
     end
 
     function _M.reverse_px_client()


### PR DESCRIPTION
Fixes first party client 404 error when a 304 status code with no body is received which continues the request pass the access phase without exiting.