### PR TITLE
Converting int to string when sending risk API call

### DIFF
--- a/lib/px/utils/pxapi.lua
+++ b/lib/px/utils/pxapi.lua
@@ -93,7 +93,7 @@ function M.load(px_config)
             px_common_utils.handle_custom_parameters(px_config, px_logger, risk.additional)
         end
 
-        risk.additional.http_version = ngx_req_http_version()
+        risk.additional.http_version = tostring(ngx_req_http_version())
         risk.additional.http_method = ngx_req_get_method()
         risk.additional.module_version = px_constants.MODULE_VERSION
         risk.additional.cookie_origin = ngx.ctx.px_cookie_origin


### PR DESCRIPTION
As per https://github.com/openresty/lua-nginx-module#ngxreqhttp_version, ngx.req.http_version returns a num or nil. Since our spec calls for this to be a string when submitted to the risk api, we need to call tostring() when assigning the result of the ngx.req.http_version() function to the API request.