### PR TITLE
Add "whitelist_ignore_uri_prefixes" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,7 @@ To deploy the PerimeterX First-Party JS Snippet:
   ----------- | ----- | ------------------ |
   **whitelist_uri_full** | `{'/api_server_full'}` | `/api_server_full?data=1` </br> but not to </br> `/api_server?data=1` |
   **whitelist_uri_prefixes** | `{'/api_server'}` | `/api_server_full?data=1` </br> but not to </br>  `/full_api_server?data=1` |
+  **whitelist_ignore_uri_prefixes** | `{'/api_server_auth'}` | Together with previous example, will prevent <br> `/api_server_auth_login` from being whitelisted. |
   **whitelist_uri_suffixes** | `{'.css'}` | `/style.css` </br> but not to </br>  `/style.js` |
   **whitelist_ip_addresses** | `{'192.168.99.1'}` | Filters requests coming from any of the listed IPs. |
   **whitelist_ua_full** | `{'Mozilla/5.0 (compatible; pingbot/2.0; http://www.pingdom.com/)'}` | Filters all requests matching this exact UA. |

--- a/lib/px/utils/pxfilters.lua
+++ b/lib/px/utils/pxfilters.lua
@@ -34,6 +34,10 @@ function M.load(px_config)
     -- _M.Whitelist['uri_prefixes'] = {'/api_server'}
     _M.Whitelist['uri_prefixes'] = px_config.whitelist_uri_prefixes and px_config.whitelist_uri_prefixes or {}
 
+    -- Any url that matches these prefixes will not be whitelisted, even if matches `whitelist_uri_prefixes`
+    _M.Whitelist['ignore_uri_prefixes'] = px_config.whitelist_ignore_uri_prefixes or {}
+
+
     -- URI Suffixes filter
     -- will filter requests where the uri starts with any of the list below.
     -- example:
@@ -118,11 +122,22 @@ function M.load(px_config)
             end
         end
 
-        local wluri = _M.Whitelist['uri_prefixes']
+        local whitelist_prefix_cancel = false
+        local wluri = _M.Whitelist['ignore_uri_prefixes']
         for i = 1, #wluri do
             if string_sub(uri, 1, string_len(wluri[i])) == wluri[i] then
-                px_logger.debug("Whitelisted: uri_prefixes. " .. wluri[i])
-                return true
+                whitelist_prefix_cancel = true
+                break
+            end
+        end
+
+        if not whitelist_prefix_cancel then
+            local wluri = _M.Whitelist['uri_prefixes']
+            for i = 1, #wluri do
+                if string_sub(uri, 1, string_len(wluri[i])) == wluri[i] then
+                    px_logger.debug("Whitelisted: uri_prefixes. " .. wluri[i])
+                    return true
+                end
             end
         end
 


### PR DESCRIPTION
This can be useful when some product is integrated with PX endpoint by endpoint. So at first whole
/api/ is whitelisted, then /api/aaa should be processed, then /api/bbb should also be processed. At the end, when the transition is over, etc. In this case, until the transition is over /api/ will remain whitelisted and specific endpoints will go to `whitelist_ignore_uri_prefixes`.