### PR TITLE
Login credentials fixes

### DIFF
--- a/lib/px/pxnginx.lua
+++ b/lib/px/pxnginx.lua
@@ -77,7 +77,7 @@ function M.application(px_configuration_table)
         px_logger.debug("Evaluating Risk API request, call reason: " .. result.message)
         ngx.ctx.s2s_call_reason = result.message
         local cookie_expires = 31536000 -- one year
-        local request_data = px_api.new_request_object(result.message)
+        local request_data = px_api.new_request_object(result.message, details)
         local start_risk_rtt = px_common_utils.get_time_in_milliseconds()
         local success, response = pcall(px_api.call_s2s, request_data, risk_api_path, auth_token)
         local cookie_secure_directive = ""

--- a/lib/px/utils/pxapi.lua
+++ b/lib/px/utils/pxapi.lua
@@ -26,7 +26,7 @@ function M.load(px_config)
     -- new_request_object --
     -- takes no arguments
     -- returns table
-    function _M.new_request_object(call_reason)
+    function _M.new_request_object(call_reason, details)
         local risk = {}
         local cookieHeader = px_headers.get_header("cookie")
         local vid_source = "none"
@@ -102,6 +102,14 @@ function M.load(px_config)
             risk.additional.risk_mode = "active_blocking"
         else
             risk.additional.risk_mode = "monitor"
+        end
+
+        if details["user"] then
+            risk.additional.user = details["user"]
+        end
+
+        if details["pass"] then
+            risk.additional.pass = details["pass"]
         end
 
         return risk

--- a/lib/px/utils/pxlogin_credentials.lua
+++ b/lib/px/utils/pxlogin_credentials.lua
@@ -89,7 +89,7 @@ function M.load(px_config)
     -- extract login information from client request
     -- return table or nil
     function _M.px_credentials_extract()
-        if px_config.Creds == nil then
+        if px_config.creds == nil then
             return nil
         end
 
@@ -99,7 +99,7 @@ function M.load(px_config)
 
         -- check creds path and method
         local uri = ngx.var.uri
-        for k, v in pairs(px_config.Creds) do
+        for k, v in pairs(px_config.creds) do
             if v.path == uri and v.method == method then
                 ci = v
                 break
@@ -127,7 +127,7 @@ function M.load(px_config)
     end
 
     -- check if login credentials settings are already loaded
-    if px_config.Creds then
+    if px_config.creds then
         return _M
     end
 
@@ -145,7 +145,7 @@ function M.load(px_config)
     if not success then
         px_logger.error("Could not decode login credentials JSON file")
     else
-        px_config.Creds = creds_json.features.credentials.items
+        px_config.creds = creds_json.features.credentials.items
     end
 
     return _M

--- a/lib/px/utils/pxtimer.lua
+++ b/lib/px/utils/pxtimer.lua
@@ -13,7 +13,9 @@ function M.application(px_configutraion_table)
 	local px_logger = require ("px.utils.pxlogger").load(px_config)
 	local px_constants = require("px.utils.pxconstants")
 	local buffer = require "px.utils.pxbuffer"
-	local px_creds = require ("px.utils.pxlogin_credentials").load(px_config)
+
+    -- load login credentials settings at the application startup
+	local px_creds = require("px.utils.pxlogin_credentials").load(px_config)
 
 	local ngx_timer_at = ngx.timer.at
 


### PR DESCRIPTION
* Run JSON decode in protected mode
* Load creds settings only once at the application startup
* Send creds user / pass in RiskAPI additional object