### PR TITLE
Allow whitelisting uri by lua pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,7 @@ Several filters can be configured:
    _M.whitelist_uri_full = { _M.custom_block_url },
    _M.whitelist_uri_prefixes = {},
    _M.whitelist_uri_suffixes = {'.css', '.bmp', '.tif', '.ttf', '.docx', '.woff2', '.js', '.pict', '.tiff', '.eot', '.xlsx', '.jpg', '.csv', '.eps', '.woff', '.xls', '.jpeg', '.doc', '.ejs', '.otf', '.pptx', '.gif', '.pdf', '.swf', '.svg', '.ps', '.ico', '.pls', '.midi', '.svgz', '.class', '.png', '.ppt', '.mid', '.webp', '.jar'},
+   _M.whitelist_uri_pattern = {},
    _M.whitelist_ip_addresses = {},
    _M.whitelist_ua_full = {},
    _M.whitelist_ua_sub = {}
@@ -659,6 +660,7 @@ Several filters can be configured:
 | **whitelist_uri_full**     | `{'/api_server_full'}`                                               | `/api_server_full?data=1` </br> but not to </br> `/api_server?data=1`      |
 | **whitelist_uri_prefixes** | `{'/api_server'}`                                                    | `/api_server_full?data=1` </br> but not to </br> `/full_api_server?data=1` |
 | **whitelist_uri_suffixes** | `{'.css'}`                                                           | `/style.css` </br> but not to </br> `/style.js`                            |
+| **whitelist_uri_pattern**  | `{'/api/.*/server'}`                                                 | `/api/any/thing/server?data=1` </br> but not to </br> `/api/api_server`    |
 | **whitelist_ip_addresses** | `{'192.168.99.1'}`                                                   | Filters requests coming from any of the listed IPs.                        |
 | **whitelist_ua_full**      | `{'Mozilla/5.0 (compatible; pingbot/2.0; http://www.pingdom.com/)'}` | Filters all requests matching this exact UA.                               |
 | **whitelist_ua_sub**       | `{'GoogleCloudMonitoring'}`                                          | Filters requests containing the provided string in their UA.               |

--- a/lib/px/utils/config_builder.lua
+++ b/lib/px/utils/config_builder.lua
@@ -53,6 +53,7 @@ PX_DEFAULT_CONFIGURATIONS["client_port_overide"] = { nil, "number"}
 PX_DEFAULT_CONFIGURATIONS["proxy_url"] = { nil, "string"}
 PX_DEFAULT_CONFIGURATIONS["proxy_authorization"] = { nil, "string"}
 PX_DEFAULT_CONFIGURATIONS["whitelist_uri_full"] = { {}, "table"}
+PX_DEFAULT_CONFIGURATIONS["whitelist_uri_pattern"] = { {}, "table"}
 PX_DEFAULT_CONFIGURATIONS["whitelist_uri_prefixes"] = { {}, "table"}
 PX_DEFAULT_CONFIGURATIONS["whitelist_uri_suffixes"] = { {'.css', '.bmp', '.tif', '.ttf', '.docx', '.woff2', '.js', '.pict', '.tiff', '.eot', '.xlsx', '.jpg', '.csv', '.eps', '.woff', '.xls', '.jpeg', '.doc', '.ejs', '.otf', '.pptx', '.gif', '.pdf', '.swf', '.svg', '.ps', '.ico', '.pls', '.midi', '.svgz', '.class', '.png', '.ppt', '.mid', '.webp', '.jar'}, "table"}
 PX_DEFAULT_CONFIGURATIONS["whitelist_ip_addresses"] = { {}, "table"}

--- a/lib/px/utils/pxfilters.lua
+++ b/lib/px/utils/pxfilters.lua
@@ -41,6 +41,15 @@ function M.load(px_config)
     -- _M.Whitelist['uri_suffixes'] = {'.css'}
     _M.Whitelist['uri_suffixes'] = px_config.whitelist_uri_suffixes and px_config.whitelist_uri_suffixes or {}
 
+    -- URI Suffixes filter
+    -- will filter requests where the uri matches any lua pattern in the list below.
+    -- example:
+    -- filter: example.com/aaa/anthing/api_server?data=data
+    -- _M.Whitelist['uri_pattern'] = {'/aaa/.*/api_server'}
+    -- For clearness, the pattern always requires to match full uri path, so if you want to match from the middle
+    -- you need to all `.*` in the beginning
+    _M.Whitelist['uri_pattern'] = px_config.whitelist_uri_pattern or {}
+
     -- IP Addresses filter
     -- will filter requests coming from the ip in the list below
     -- _M.Whitelist['ip_addresses'] = {'192.168.99.1'}
@@ -130,6 +139,14 @@ function M.load(px_config)
         for i = 1, #wluris do
             if string_sub(uri, -string_len(wluris[i])) == wluris[i] then
                 px_logger.debug("Whitelisted: uri_suffix. " .. wluris[i])
+                return true
+            end
+        end
+
+        local wluris = _M.Whitelist['uri_pattern']
+        for i = 1, #wluris do
+            if string.find(uri, '^' .. wluris[i] .. '$') then
+                px_logger.debug("Whitelisted: uri_pattern. " .. wluris[i])
                 return true
             end
         end


### PR DESCRIPTION
The use case is whitelisting a following URL: `/user/<user-id>/info`,
while not whitelisting URLs like: `/user/<user-id>/validate`, or `/user/<user-id>/reset-password`
