### PR TITLE
Implement fetch status code feature

### DIFF
--- a/lib/px/pxconfig.lua
+++ b/lib/px/pxconfig.lua
@@ -81,4 +81,8 @@ _M.auth_token = 'PX_AUTH_TOKEN'
 --_M.px_enable_login_creds_extraction = false
 --_M.px_login_creds_settings_filename = nil
 
+-- ## Page Requested Settings
+-- postpone_page_requested: if true then finalize() must be called from header_filter_by_lua_block to finalize the request processing
+-- _M.postpone_page_requested = false
+
 return _M

--- a/lib/px/pxnginx.lua
+++ b/lib/px/pxnginx.lua
@@ -25,9 +25,7 @@
 local M = {}
 M.configLoaded = false
 
--- postpone_page_requested: optional parameter,
---  if true then finalize() must be called to finalize the request processing
-function M.application(px_configuration_table, postpone_page_requested)
+function M.application(px_configuration_table)
     local config_builder = require("px.utils.config_builder")
 
     local px_config = config_builder.load(px_configuration_table)
@@ -268,7 +266,7 @@ function M.application(px_configuration_table, postpone_page_requested)
     px_data["details"] = details
     px_data["finalized"] = false
 
-    if not postpone_page_requested then
+    if px_config.postpone_page_requested == nil or not px_config.postpone_page_requested then
         M.finalize(px_data)
     else
         return px_data

--- a/lib/px/pxnginx.lua
+++ b/lib/px/pxnginx.lua
@@ -24,7 +24,10 @@
 
 local M = {}
 M.configLoaded = false
-function M.application(px_configuration_table)
+
+-- postpone_page_requested: optional parameter,
+--  if true then finalize() must be called to finalize the request processing
+function M.application(px_configuration_table, postpone_page_requested)
     local config_builder = require("px.utils.config_builder")
 
     local px_config = config_builder.load(px_configuration_table)
@@ -108,7 +111,6 @@ function M.application(px_configuration_table)
             end
             -- score did not cross the blocking threshold
             ngx.ctx.pass_reason = 's2s'
-            pcall(px_client.send_to_perimeterx, "page_requested", details)
             return true
         else
             -- server2server call failed, passing traffic
@@ -118,11 +120,15 @@ function M.application(px_configuration_table)
                 ngx.ctx.pass_reason = 's2s_timeout'
             end
             px_logger.debug('Risk API failed with error: ' .. response)
-            px_client.send_to_perimeterx("page_requested", details)
 
             return true
         end
     end
+
+    -- by default it's set as finalized, no need to call page_requested
+    px_data = {}
+    px_data["finalized"] = true
+    px_data["px_config"] = px_config
 
     -- check for x-px-enforcer-telemetry header
     local ran, error_msg = pcall(px_telemetry.telemetry_check_header, px_config, px_client, px_headers, px_logger)
@@ -132,12 +138,12 @@ function M.application(px_configuration_table)
 
     -- Match for client/XHRs/captcha
     if is_first_party_request(reverse_prefix, lower_request_url) then
-        return true
+        return px_data
     end
 
     if not px_config.px_enabled then
         px_logger.debug("Request will not be verified, module is disabled")
-        return true
+        return px_data
     end
 
     local valid_route = false
@@ -152,7 +158,7 @@ function M.application(px_configuration_table)
 
     if not valid_route and #enabled_routes > 0 then
         px_headers.set_score_header(0)
-        return true
+        return px_data
     end
 
      -- Check for monitored route
@@ -165,7 +171,7 @@ function M.application(px_configuration_table)
 
     -- Validate if request is from internal redirect to avoid duplicate processing
     if px_headers.validate_internal_request() then
-        return true
+        return px_data
     end
 
     -- Clean any protected headers from the request.
@@ -175,7 +181,7 @@ function M.application(px_configuration_table)
     -- run filter and whitelisting logic
     if (px_filters.process()) then
         px_headers.set_score_header(0)
-        return true
+        return px_data
     end
 
     px_logger.debug("Starting request verification. IP: " .. remote_addr .. ". UA: " .. user_agent)
@@ -245,22 +251,42 @@ function M.application(px_configuration_table)
         -- score crossed threshold
         if result == false then
             ngx.ctx.block_reason = 'cookie_high_score'
-            return px_block.block(ngx.ctx.block_reason)
+            px_block.block(ngx.ctx.block_reason)
+            return px_data
         else
             ngx.ctx.pass_reason = 'cookie'
-            pcall(px_client.send_to_perimeterx, "page_requested", details)
-            return true
         end
     elseif enable_server_calls == true then
         if result == nil then
             result = { message = "cookie_error" }
         end
-        return perform_s2s(result, details)
+        perform_s2s(result, details)
     else
         ngx.ctx.pass_reason = 'error'
-        pcall(px_client.send_to_perimeterx, "page_requested", details)
-        return true
     end
+
+    px_data["details"] = details
+    px_data["finalized"] = false
+
+    if not postpone_page_requested then
+        M.finalize(px_data)
+    else
+        return px_data
+    end
+end
+
+-- if postpone_page_requested is set to true, then this function
+-- must be called from header_filter_by_lua_block{}
+function M.finalize(px_data)
+    if not px_data or px_data["finalized"] then
+        return
+    end
+
+    local px_client = require("px.utils.pxclient").load(px_data["px_config"])
+
+    -- set Upstream status code, if no upstream server, then it will contain nil
+    px_data["details"]["status_code"] = ngx.var.upstream_status
+    pcall(px_client.send_to_perimeterx, "page_requested", px_data["details"])
 end
 
 return M

--- a/lib/px/pxnginx.lua
+++ b/lib/px/pxnginx.lua
@@ -124,7 +124,7 @@ function M.application(px_configuration_table)
     end
 
     -- by default it's set as finalized, no need to call page_requested
-    px_data = {}
+    local px_data = {}
     px_data["finalized"] = true
     px_data["px_config"] = px_config
 

--- a/lib/px/utils/config_builder.lua
+++ b/lib/px/utils/config_builder.lua
@@ -63,6 +63,7 @@ PX_DEFAULT_CONFIGURATIONS["custom_cookie_header"] = { nil, "string"}
 PX_DEFAULT_CONFIGURATIONS["bypass_monitor_header"] = { nil, "string"}
 PX_DEFAULT_CONFIGURATIONS["px_enable_login_creds_extraction"] = { false, "boolean"}
 PX_DEFAULT_CONFIGURATIONS["px_login_creds_settings_filename"] = { nil, "string"}
+PX_DEFAULT_CONFIGURATIONS["postpone_page_requested"] = { false, "boolean"}
 
 function _M.load(px_config)
     local ngx_log = ngx.log

--- a/nginx.conf
+++ b/nginx.conf
@@ -30,14 +30,24 @@ http {
             #----- PerimeterX Module Start -----#
             access_by_lua_block {
                 local config = require('px.pxconfig')
-                require("px.pxnginx").application(config)
+                local pxnginx = require("px.pxnginx")
+                px_data = pxnginx.application(config, true)
+            }
+
+            header_filter_by_lua_block {
+                local pxnginx = require("px.pxnginx")
+                pxnginx.finalize(px_data)
             }
             #----- PerimeterX Module End   -----#
             add_header Cache-Control "private, max-age=0, no-cache";
+
             root   html;
             index  index.html;
 
             include  mime.types;
+
+            # to test Upstream status, run a web server on 8081 port and enable proxy_pass:
+            # proxy_pass http://127.0.0.1:8081;
         }
     }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -31,7 +31,7 @@ http {
             access_by_lua_block {
                 local config = require('px.pxconfig')
                 local pxnginx = require("px.pxnginx")
-                px_data = pxnginx.application(config, true)
+                px_data = pxnginx.application(config)
             }
 
             header_filter_by_lua_block {


### PR DESCRIPTION
Return `px_data` from `M.application()`, which contains `details` and `px_config`.
Then from `header_filter_by_lua_block {}` Nginx block (which is executed *after* communication with an Upstream) call `M.finalize()` to send `page_requested` JSON if needed.