### PR TITLE
Don't send credentials with async activities

### DIFF
--- a/lib/px/block/pxblock.lua
+++ b/lib/px/block/pxblock.lua
@@ -81,13 +81,6 @@ function M.load(px_config)
             px_logger.enrich_log("pxvid", ngx.ctx.vid)
         end
 
-        if creds then
-            details.user = creds["user"]
-            details.pass = creds["pass"]
-            details.ci_version = creds["ci_version"]
-            details.sso_step = creds["sso_step"]
-        end
-
         if graphql then
             details["graphql_operation_name"] = graphql["operationName"]
             details["graphql_operation_type"] = graphql["operationType"]
@@ -95,7 +88,7 @@ function M.load(px_config)
 
         px_logger.enrich_log('pxaction', ngx.ctx.px_action)
 
-        px_client.send_to_perimeterx('block', details)
+        px_client.send_to_perimeterx('block', details, creds)
 
         local should_bypass_monitor = px_config.bypass_monitor_header and px_headers.get_header(px_config.bypass_monitor_header) == '1'
 

--- a/lib/px/pxnginx.lua
+++ b/lib/px/pxnginx.lua
@@ -122,7 +122,7 @@ function M.application(px_configuration_table)
             end
             -- score did not cross the blocking threshold
             ngx.ctx.pass_reason = 's2s'
-            pcall(px_client.send_to_perimeterx, "page_requested", details)
+            pcall(px_client.send_to_perimeterx, "page_requested", details, creds)
             return true
         else
             -- server2server call failed, passing traffic
@@ -132,7 +132,7 @@ function M.application(px_configuration_table)
                 ngx.ctx.pass_reason = 's2s_timeout'
             end
             px_logger.debug('Risk API failed with error: ' .. response)
-            px_client.send_to_perimeterx("page_requested", details)
+            px_client.send_to_perimeterx("page_requested", details, creds)
             return true
         end
     end
@@ -297,7 +297,7 @@ function M.application(px_configuration_table)
             return px_data
         else
             ngx.ctx.pass_reason = 'cookie'
-            pcall(px_client.send_to_perimeterx, "page_requested", details)
+            pcall(px_client.send_to_perimeterx, "page_requested", details, creds)
         end
     elseif enable_server_calls == true then
         if result == nil then
@@ -306,7 +306,7 @@ function M.application(px_configuration_table)
         perform_s2s(result, details, creds, graphql)
     else
         ngx.ctx.pass_reason = 'error'
-        pcall(px_client.send_to_perimeterx, "page_requested", details)
+        pcall(px_client.send_to_perimeterx, "page_requested", details, creds)
     end
 
     px_data["details"] = details

--- a/lib/px/utils/pxclient.lua
+++ b/lib/px/utils/pxclient.lua
@@ -82,7 +82,7 @@ function M.load(px_config)
         end
     end
 
-    function _M.send_to_perimeterx(event_type, details)
+    function _M.send_to_perimeterx(event_type, details, creds)
         local maxbuflen = px_config.px_maxbuflen
         local full_url = ngx.var.scheme .. "://" .. ngx.var.host .. ngx.var.request_uri
 
@@ -133,6 +133,16 @@ function M.load(px_config)
 
         if ngx.ctx.px_cookie then
             details['px_cookie_hmac'] = ngx.ctx.px_cookie_hmac
+        end
+
+        if creds then
+            details["ci_version"] = creds["ci_version"]
+            details["sso_step"] = creds["sso_step"]
+            if ngx.ctx.breached_account then
+                details["credentials_compromised"] = true
+            else
+                details["credentials_compromised"] = false
+            end
         end
 
         if px_config.enrich_custom_parameters ~= nil then


### PR DESCRIPTION
We shouldn’t send the async activities with credentials, but we SHOULD include fields like credentials_compromised / ci_version / sso_step on both page_requested AND block

