### PR TITLE
change rockspec protocol to https instead of git://

### DIFF
--- a/perimeterx-nginx-plugin-7.0.0-1.rockspec
+++ b/perimeterx-nginx-plugin-7.0.0-1.rockspec
@@ -1,7 +1,7 @@
  package = "perimeterx-nginx-plugin"
  version = "7.0.0-1"
  source = {
-    url = "git://github.com/PerimeterX/perimeterx-nginx-plugin.git",
+    url = "https://github.com/PerimeterX/perimeterx-nginx-plugin.git",
     tag = "v7.0.0",
  }
  description = {

--- a/perimeterx-nginx-plugin-7.0.0-1.rockspec
+++ b/perimeterx-nginx-plugin-7.0.0-1.rockspec
@@ -1,7 +1,7 @@
  package = "perimeterx-nginx-plugin"
  version = "7.0.0-1"
  source = {
-    url = "https://github.com/PerimeterX/perimeterx-nginx-plugin.git",
+    url = "git+https://github.com/PerimeterX/perimeterx-nginx-plugin.git",
     tag = "v7.0.0",
  }
  description = {


### PR DESCRIPTION
Necessary to upload to luarocks to prevent the following error:

```
Packing perimeterx-nginx-plugin
Cloning into 'perimeterx-nginx-plugin'...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

Error: Failed cloning git repository.
```