### PR TITLE
Fix field name in telemetry command

### DIFF
--- a/lib/px/utils/pxcommonutils.lua
+++ b/lib/px/utils/pxcommonutils.lua
@@ -147,6 +147,11 @@ function  _M.filter_config(px_config)
     -- remove
     config_copy.cookie_secret = nil
     config_copy.auth_token = nil
+    -- functions
+    config_copy.additional_activity_handler = nil
+    config_copy.enrich_custom_parameters = nil
+    config_copy.custom_login_successful = nil
+
     return config_copy
 end
 

--- a/lib/px/utils/pxtelemetry.lua
+++ b/lib/px/utils/pxtelemetry.lua
@@ -5,15 +5,15 @@ local hmac = require "resty.nettle.hmac"
 local M = {}
 
 function M.telemetry_check_header(px_config, px_client, px_headers, px_logger)
-    local header_value = px_headers.get_header(px_constants.ENFORCER_TELEMETRY_HEADER)
-    if not header_value then
+    local header_value_in = px_headers.get_header(px_constants.ENFORCER_TELEMETRY_HEADER)
+    if not header_value_in then
         return
     end
     px_logger.debug('Received command to send enforcer telemetry')
-    header_value = ngx.decode_base64(header_value)
+    local header_value = ngx.decode_base64(header_value_in)
     local split_header_value = px_common_utils.split_first(header_value, '[%:]+')
     if #split_header_value ~= 2 then
-        px_logger.debug('Malformed ' .. px_constants.ENFORCER_TELEMETRY_HEADER .. ' header: ' .. header_value)
+        px_logger.debug('Malformed ' .. px_constants.ENFORCER_TELEMETRY_HEADER .. ' header: ' .. header_value_in)
         return
     end
     local timestamp = split_header_value[1]
@@ -34,7 +34,7 @@ function M.telemetry_check_header(px_config, px_client, px_headers, px_logger)
     end
 
     local details = {}
-    details.px_config = px_common_utils.filter_config(px_config)
+    details.enforcer_configs = px_common_utils.filter_config(px_config)
     details.update_reason = 'command'
     px_client.send_enforcer_telmetry(details)
 end


### PR DESCRIPTION
* rename px_config field to enforcer_configs
* filter functions from configuration object