### PR TITLE
Properly handle multiple instances of the same header

### DIFF
--- a/lib/px/block/pxblock.lua
+++ b/lib/px/block/pxblock.lua
@@ -20,6 +20,7 @@ function M.load(px_config)
     local px_headers = require("px.utils.pxheaders").load(px_config)
     local cjson = require "cjson"
     local px_constants = require "px.utils.pxconstants"
+    local px_common_utils = require("px.utils.pxcommonutils")
     local ngx_exit = ngx.exit
     local string_gsub = string.gsub
 
@@ -130,7 +131,7 @@ function M.load(px_config)
         end
 
         -- json response
-        local accept_header = ngx.req.get_headers()["accept"] or ngx.req.get_headers()["content-type"]
+        local accept_header = px_common_utils.get_headers_single("accept") or px_common_utils.get_headers_single("content-type")
         local is_json_response = px_config.advanced_blocking_response and accept_header and is_accept_header_json(accept_header) and not ngx.ctx.px_is_mobile
         if is_json_response then
             local props = px_template.get_props(px_config, details.block_uuid, vid, parse_action(ngx.ctx.px_action))
@@ -218,7 +219,7 @@ function M.load(px_config)
         ngx.status = ngx_HTTP_FORBIDDEN
         if px_config.api_protection_mode then
             -- api protection mode
-            local redirect_url = ngx.req.get_headers()['Referer']
+            local redirect_url = px_common_utils.get_headers_single('referer')
             if redirect_url == nil or redirect_url == '' then
                 redirect_url = px_config.api_protection_default_redirect_url
             end

--- a/lib/px/utils/pxclient.lua
+++ b/lib/px/utils/pxclient.lua
@@ -364,7 +364,7 @@ function M.load(px_config)
             ngx_req_set_header('cookie', 'pxvid=' .. vid)
         end
 
-        local xff_header = ngx.req.get_headers()['X-Forwarded-For']
+        local xff_header = px_common_utils.get_headers_single('x-forwarded-for')
         if xff_header then
             xff_header = xff_header .. ', ' .. ngx.var.remote_addr
         else

--- a/lib/px/utils/pxcommonutils.lua
+++ b/lib/px/utils/pxcommonutils.lua
@@ -182,6 +182,27 @@ function _M.clear_first_party_sensitive_headers(sensitive_headers)
     end
 end
 
+-- h: header name
+-- return header value or nil
+-- if there are multiple headers - return the 1st header's value
+function _M.get_headers_single(h)
+    local hdr, e = ngx.req.get_headers()[h]
+    if hdr == nil then
+        return nil
+    end
+
+    if type(hdr) == 'table' then
+        for _,v in pairs(hdr) do
+            if v ~= nil then
+                return v
+            end
+        end
+        return nil
+    end
+
+    return hdr
+end
+
 -- Splits a string into array
 -- @s - string to split
 -- @delimeter - delimeiter to use

--- a/lib/px/utils/pxlogin_credentials.lua
+++ b/lib/px/utils/pxlogin_credentials.lua
@@ -237,7 +237,7 @@ function M.load(px_config)
     end
 
     function _M.creds_extract_from_body(ci)
-        local ctype = ngx.req.get_headers()["content-type"]
+        local ctype = px_common_utils.get_headers_single("content-type")
         if not ctype then
             return nil
         end


### PR DESCRIPTION
A request could contain multiple instances of the same header, then Nginx Lua passes an array of values.