### PR TITLE
Add custom_enabled_routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
   - [Filter Sensitive Headers](#sensitive-headers)
   - [Remote Configurations](#remote-configurations)
   - [Enabled Routes](#enabled-routes)
+  - [Custom Enabled Routes](#custom-enabled-routes)
   - [Monitored Routes](#monitored-routes)
   - [Sensitive Routes](#sensitive-routes)
   - [Sensitive Routes Regex List](#sensitive-routes-regex)
@@ -746,6 +747,31 @@ Example:
 ```lua
  _M.enabled_routes = {'/blockhere'}
 ```
+
+### <a name="custom-enabled-routes"></a> Custom Enabled Routes
+
+Allows you to define a function, which takes `uri` as an argument and returns `true` or `false`.
+Returning `true` means that the plugin will be active for the given `uri`.
+
+**Default:** Function is not defined (all routes are active)
+
+Example:
+
+```lua
+-- return `true` if `/tmp/urls.txt` contains a string matching `uri`
+-- Warning! Reading from a file for each request could affect performance!
+_M.custom_enabled_routes = function(uri)
+    for line in io.lines("/tmp/urls.txt") do
+        -- simple substring match, could be extended to a pattern matching
+        if string.sub(uri, 1, string.len(line)) == line then
+            return true
+        end
+    end
+    return false
+end
+
+```
+
 
 ### <a name="monitored-routes"></a> Monitored Routes
 

--- a/examples/pxconfig.lua
+++ b/examples/pxconfig.lua
@@ -25,6 +25,7 @@ _M.auth_token = 'REPLACE PX_AUTH_TOKEN'
 -- _M.sensitive_routes = {}
 -- _M.additional_activity_handler = nil
 -- _M.enabled_routes = {}
+-- _M.custom_enabled_routes = nil
 -- _M.monitored_routes = {}
 -- _M.first_party_enabled = true
 -- _M.reverse_xhr_enabled = true

--- a/lib/px/pxnginx.lua
+++ b/lib/px/pxnginx.lua
@@ -204,6 +204,15 @@ function M.application(px_configuration_table)
         return px_data
     end
 
+    if px_config.custom_enabled_routes ~= nil then
+        px_logger.debug("custom_enabled_routes was triggered")
+        local res = px_config.custom_enabled_routes(ngx.var.uri)
+        if not res then
+            px_headers.set_score_header(0)
+            return px_data
+        end
+    end
+
      -- Check for monitored route
     for i = 1, #monitored_routes do
         if string_sub(ngx.var.uri, 1, string_len(monitored_routes[i])) == monitored_routes[i] then

--- a/lib/px/utils/config_builder.lua
+++ b/lib/px/utils/config_builder.lua
@@ -18,6 +18,7 @@ PX_DEFAULT_CONFIGURATIONS["sensitive_routes"] = { {}, "table"}
 PX_DEFAULT_CONFIGURATIONS["additional_activity_handler"] = { nil, "function" }
 PX_DEFAULT_CONFIGURATIONS["enrich_custom_parameters"] = { nil, "function" }
 PX_DEFAULT_CONFIGURATIONS["enabled_routes"] = { {}, "table"}
+PX_DEFAULT_CONFIGURATIONS["custom_enabled_routes"] = { nil, "function"}
 PX_DEFAULT_CONFIGURATIONS["monitored_routes"] = { {}, "table"}
 PX_DEFAULT_CONFIGURATIONS["advanced_blocking_response"] = { true, "boolean"}
 PX_DEFAULT_CONFIGURATIONS["first_party_enabled"] = { true, "boolean"}


### PR DESCRIPTION
Custom Enabled Routes

Allows to define a function, which takes `uri` as an argument and returns `true` or `false`.
Returning `true` means that the plugin will be active for the given `uri`.